### PR TITLE
Remove unused dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
             <groupId>org.eclipse.jetty.aggregate</groupId>
             <artifactId>jetty-webapp</artifactId>
             <version>${jetty.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.orbit</groupId>
+                    <artifactId>javax.servlet</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Bypass JDK 1.8.0_191+ -->
@@ -79,11 +85,31 @@
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
             <version>8.5.38</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-jsp-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-jaspic-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-el-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jasper-el</artifactId>
             <version>8.5.38</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-el-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 <!--        <dependency>-->
 <!--            <groupId>org.codehaus.groovy</groupId>-->


### PR DESCRIPTION
@welk1n Hi, I am a user of project **_welk1n:JNDI-Injection-Exploit:1.0-SNAPSHOT_**. I found that its pom file introduced **_28_** dependencies. However, among them, **_4_** libraries (**_14%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_welk1n:JNDI-Injection-Exploit:1.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.apache.tomcat:tomcat-jaspic-api:jar:8.5.38:compile
org.apache.tomcat:tomcat-el-api:jar:8.5.38:compile
org.eclipse.jetty.orbit:javax.servlet:jar:3.0.0.v201112011016:compile
org.apache.tomcat:tomcat-jsp-api:jar:8.5.38:compile
</code></pre>